### PR TITLE
Potential fix for code scanning alert no. 11: Code injection

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -35,7 +35,7 @@ jobs:
         id: parse
         run: |
           # Fetch the raw issue body via the API (handles encoding properly)
-          BODY=$(gh issue view "${{ github.event.issue.number }}" --json body -q '.body')
+          BODY=$(gh issue view "$ISSUE_NUMBER" --json body -q '.body')
           
           if echo "$BODY" | grep -qi '\[x\] \*\*Accept\*\*'; then
             OUTCOME="true_positive"
@@ -62,12 +62,20 @@ jobs:
           echo "outcome=$OUTCOME" >> $GITHUB_OUTPUT
           echo "label=$LABEL" >> $GITHUB_OUTPUT
           echo "close=$CLOSE" >> $GITHUB_OUTPUT
-          echo "author=${{ github.actor }}" >> $GITHUB_OUTPUT
-          echo "issue=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
-          echo "title=${{ github.event.issue.title }}" >> $GITHUB_OUTPUT
+          echo "author=$ISSUE_AUTHOR" >> $GITHUB_OUTPUT
+          echo "issue=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+          DELIM=$(uuidgen)
+          {
+            echo "title<<$DELIM"
+            echo "$ISSUE_TITLE"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
           echo "reason=Triaged via issue checkbox" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_AUTHOR: ${{ github.actor }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
 
       - name: Ignore unknown edits
         if: steps.parse.outputs.valid == 'false'


### PR DESCRIPTION
Potential fix for [https://github.com/jacobdjwilson/awesome-annual-security-reports/security/code-scanning/11](https://github.com/jacobdjwilson/awesome-annual-security-reports/security/code-scanning/11)

General fix: never place untrusted `${{ ... }}` directly inside `run:` shell commands. Bind it to step environment variables and consume with shell-native expansion (`$VAR`). When writing untrusted content to `$GITHUB_OUTPUT`, use the heredoc-style multiline format (`name<<EOF ... EOF`) with a unique delimiter.

Best fix here (same functionality): in `.github/workflows/issue-triage.yml`, in step **Parse triage checkbox**:
- Add step env vars for actor, issue number, and issue title from GitHub context.
- Replace direct expression echos on lines 65–67 with safe shell-variable writes.
- For title, use multiline output syntax with a random delimiter to safely preserve any content.

No new imports/dependencies are needed (workflow YAML + shell only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
