### PR TITLE
Add VirusTotal hash audit mode for unseen PDFs and fix daily scan defect

### DIFF
--- a/.github/artifacts/workflow-config.json
+++ b/.github/artifacts/workflow-config.json
@@ -180,6 +180,8 @@
       "poll_attempts": 5,
       "poll_backoff_base_seconds": 10,
       "rate_limit_sleep_seconds": 15,
+      "default_audit_batch_limit": 450,
+      "unseen_output_file": "unseen_pdfs_to_submit.txt",
       "skip_on_schedule": false,
       "skip_on_push": false,
       "python_packages": [

--- a/.github/scripts/virus-total-scan.py
+++ b/.github/scripts/virus-total-scan.py
@@ -1,16 +1,21 @@
 """
 Operational Purpose:
-    Scans PDF files against the VirusTotal v3 API (via file upload or opportunistic SHA-256 hash lookup),
-    evaluating detection stats and enforcing repository security safeguards.
+    Scans PDF files against the VirusTotal v3 API (via file upload, opportunistic SHA-256 hash lookup,
+    or batch hash audit), evaluating detection stats, discovering unseen files requiring submission,
+    and enforcing repository security safeguards.
 
 Required Environment Variables:
     VIRUS_TOTAL_API_KEY (optional): VirusTotal v3 API key.
     SKIP_VIRUS_SCAN (optional): If 'true', skips scanning.
+    VT_MODE (optional): Operational mode ('daily_scan' or 'audit_unseen').
+    VT_BATCH_LIMIT (optional): Batch limit override for audit mode.
     GITHUB_OUTPUT (optional): Path to write step outputs.
 
 Outputs:
     scan_skipped (bool): 'true' if scan was bypassed, 'false' otherwise.
     scan_passed (bool): 'true' if no files were flagged malicious and scan completed.
+    checked_count (int): Number of file hashes queried during audit mode.
+    unseen_count (int): Total number of files identified as never seen by VirusTotal.
 
 JSON Artifact Dependencies:
     .github/artifacts/workflow-config.json (workflow.virustotal)
@@ -59,6 +64,8 @@ class ConfigLoader:
             "poll_attempts",
             "poll_backoff_base_seconds",
             "rate_limit_sleep_seconds",
+            "default_audit_batch_limit",
+            "unseen_output_file",
             "skip_on_schedule",
             "skip_on_push",
         ]
@@ -72,6 +79,8 @@ class ConfigLoader:
         self.poll_attempts:             int  = int(vt["poll_attempts"])
         self.poll_backoff_base_seconds: int  = int(vt["poll_backoff_base_seconds"])
         self.rate_limit_sleep_seconds:  int  = int(vt["rate_limit_sleep_seconds"])
+        self.default_audit_batch_limit: int  = int(vt["default_audit_batch_limit"])
+        self.unseen_output_file:        str  = str(vt["unseen_output_file"])
         self.skip_on_schedule:          bool = bool(vt["skip_on_schedule"])
         self.skip_on_push:              bool = bool(vt["skip_on_push"])
 
@@ -228,7 +237,8 @@ def daily_scan_mode(files_list: list, api_key: str, cfg: ConfigLoader, artifacts
                 if malicious_count > 0:
                     print(f"::error file={file_path}::VirusTotal Daily Scan found MALICIOUS file: {file_path}")
                     return 1
-                return 0
+                time.sleep(cfg.rate_limit_sleep_seconds)
+                continue
             elif resp.status_code == 404:
                 print("File not found on VirusTotal. Uploading...")
                 analysis_id = upload_file(file_path, api_key, cfg)
@@ -241,14 +251,191 @@ def daily_scan_mode(files_list: list, api_key: str, cfg: ConfigLoader, artifacts
                     print("Failed to upload file.")
                 return 0
             elif resp.status_code == 429:
-                print("Rate limited checking new file. Will try tomorrow.")
+                print("Rate limited or quota exceeded checking new file. Will try tomorrow.")
                 return 0
             else:
                 print(f"Unexpected HTTP {resp.status_code} checking new file.")
-                return 0
-                
+                time.sleep(cfg.rate_limit_sleep_seconds)
+                continue
+
     print("No unscanned files found.")
     return 0
+
+
+def audit_unseen_mode(
+    files_list: list,
+    api_key: str,
+    cfg: ConfigLoader,
+    artifacts_dir: str,
+    batch_limit: int,
+    output_unseen_file: str,
+    output_unseen_json: str
+) -> int:
+    """
+    Audits PDF file SHA-256 hashes against VirusTotal v3 API.
+    Identifies files never seen by VirusTotal (HTTP 404) and writes them to an unseen list.
+    """
+    tracking_file = Path(artifacts_dir) / "vt-scanned.json"
+    tracking_data = {}
+    if tracking_file.exists():
+        try:
+            with open(tracking_file, "r", encoding="utf-8") as f:
+                tracking_data = json.load(f)
+        except Exception as e:
+            print(f"Warning: Failed to parse existing tracking file: {e}")
+            tracking_data = {}
+
+    unseen_records = []
+    unseen_json_path = Path(output_unseen_json)
+    if unseen_json_path.exists():
+        try:
+            with open(unseen_json_path, "r", encoding="utf-8") as f:
+                prior = json.load(f)
+                if isinstance(prior, list):
+                    unseen_records = prior
+                elif isinstance(prior, dict) and "unseen_files" in prior:
+                    unseen_records = prior["unseen_files"]
+        except Exception:
+            pass
+
+    unseen_hashes = {u.get("sha256") for u in unseen_records if isinstance(u, dict)}
+
+    for fhash, info in tracking_data.items():
+        if info.get("status") == "unseen" and fhash not in unseen_hashes:
+            unseen_records.append({
+                "file": info.get("file", ""),
+                "sha256": fhash,
+                "reason": "Never seen on VirusTotal (from cache)"
+            })
+            unseen_hashes.add(fhash)
+
+    print(f"\n{'='*70}")
+    print("VirusTotal Unseen PDF Hash Audit")
+    print(f"{'='*70}\n")
+    print(f"Total PDFs queued:            {len(files_list)}")
+    print(f"Batch limit for this run:     {batch_limit}")
+    print(f"Already seen (completed):    {sum(1 for v in tracking_data.values() if v.get('status') in ('completed', 'uploaded'))}")
+    print(f"Already identified unseen:    {len(unseen_hashes)}\n")
+
+    base_url = cfg.api_base_url
+    headers = {"x-apikey": api_key, "User-Agent": cfg.user_agent, "Accept": "application/json"}
+
+    checked_this_run = 0
+    new_seen = 0
+    new_unseen = 0
+    rate_limited = False
+
+    for file_path in files_list:
+        if not os.path.exists(file_path):
+            continue
+
+        fhash = calculate_file_hash(file_path)
+
+        # Skip already completed or known unseen
+        if fhash in tracking_data and tracking_data[fhash].get("status") in ("completed", "uploaded"):
+            continue
+        if fhash in unseen_hashes:
+            continue
+
+        if checked_this_run >= batch_limit:
+            print(f"\nReached batch limit of {batch_limit} files for this run.")
+            break
+
+        checked_this_run += 1
+        print(f"[{checked_this_run}/{batch_limit}] Auditing: {file_path}")
+
+        try:
+            resp = requests.get(f"{base_url}/files/{fhash}", headers=headers, timeout=30)
+            if resp.status_code == 429:
+                print(f"  ⚠ Rate limited (HTTP 429), waiting {cfg.rate_limit_sleep_seconds}s before retry...")
+                time.sleep(cfg.rate_limit_sleep_seconds)
+                resp = requests.get(f"{base_url}/files/{fhash}", headers=headers, timeout=30)
+
+            if resp.status_code == 200:
+                scan_data = resp.json()
+                attrs = scan_data.get("data", {}).get("attributes", {})
+                stats = attrs.get("last_analysis_stats", {})
+                malicious_count = stats.get("malicious", 0)
+                verdict = "Malicious" if malicious_count > 0 else "Clean"
+                print(f"  ✓ Seen on VirusTotal: {verdict} ({malicious_count} malicious detections)")
+                tracking_data[fhash] = {
+                    "status": "completed",
+                    "file": file_path,
+                    "verdict": verdict,
+                    "malicious_count": malicious_count
+                }
+                new_seen += 1
+            elif resp.status_code == 404:
+                print(f"  ✗ NEVER SEEN on VirusTotal (HTTP 404) — Needs Submission!")
+                tracking_data[fhash] = {
+                    "status": "unseen",
+                    "file": file_path
+                }
+                rec = {
+                    "file": file_path,
+                    "sha256": fhash,
+                    "reason": "Never seen on VirusTotal (HTTP 404)"
+                }
+                unseen_records.append(rec)
+                unseen_hashes.add(fhash)
+                new_unseen += 1
+            elif resp.status_code == 429:
+                print("  ❌ Daily quota or rate limit exceeded (HTTP 429). Halting audit run gracefully.")
+                rate_limited = True
+                break
+            else:
+                print(f"  ⚠ Unexpected HTTP {resp.status_code} for {file_path}.")
+        except Exception as e:
+            print(f"  ⚠ Error querying hash {fhash}: {e}")
+
+        # Continuously persist tracking data after each lookup
+        try:
+            with open(tracking_file, "w", encoding="utf-8") as f:
+                json.dump(tracking_data, f, indent=2)
+        except Exception as e:
+            print(f"Warning: Failed to persist tracking file: {e}")
+
+        if checked_this_run < batch_limit and not rate_limited:
+            time.sleep(cfg.rate_limit_sleep_seconds)
+
+    # Save final outputs
+    with open(output_unseen_file, "w", encoding="utf-8") as f:
+        for item in unseen_records:
+            f.write(f"{item['file']}\n")
+
+    detailed_output = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "total_unseen_count": len(unseen_records),
+        "checked_in_this_run": checked_this_run,
+        "new_seen_in_this_run": new_seen,
+        "new_unseen_in_this_run": new_unseen,
+        "rate_limited": rate_limited,
+        "unseen_files": unseen_records
+    }
+    with open(output_unseen_json, "w", encoding="utf-8") as f:
+        json.dump(detailed_output, f, indent=2)
+
+    print(f"\n{'='*70}")
+    print("Audit Run Complete")
+    print(f"{'='*70}")
+    print(f"Checked this run:        {checked_this_run}")
+    print(f"Newly recorded Seen:     {new_seen}")
+    print(f"Newly recorded Unseen:   {new_unseen}")
+    print(f"Total Unseen to Submit:  {len(unseen_records)}")
+    print(f"Unseen text list saved:  {output_unseen_file}")
+    print(f"Unseen detailed JSON:    {output_unseen_json}")
+    print(f"{'='*70}\n")
+
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a", encoding="utf-8") as f:
+            f.write(f"checked_count={checked_this_run}\n")
+            f.write(f"unseen_count={len(unseen_records)}\n")
+            f.write(f"new_unseen_count={new_unseen}\n")
+            f.write(f"rate_limited={'true' if rate_limited else 'false'}\n")
+
+    return 0
+
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="VirusTotal file scanner")
@@ -258,6 +445,10 @@ def main() -> int:
     ap.add_argument("--output-json", default="scan_results.json", help="Path to write results JSON")
     ap.add_argument("--artifacts-dir", default=".github/artifacts", help="Directory containing workflow-config.json")
     ap.add_argument("--daily-mode", action="store_true", help="Run the daily background scan logic")
+    ap.add_argument("--audit-unseen", action="store_true", help="Audit all PDF hashes against VT to find unseen files")
+    ap.add_argument("--batch-limit", type=int, default=None, help="Maximum number of hashes to query in this run")
+    ap.add_argument("--unseen-output", default=None, help="Path to write unseen PDFs list")
+    ap.add_argument("--unseen-json", default="unseen_pdfs_to_submit.json", help="Path to write detailed unseen JSON")
     args = ap.parse_args()
 
     print(f"\n{'='*70}")
@@ -293,7 +484,29 @@ def main() -> int:
                 f.write("scan_passed=true\n")
         return 0
 
-    if args.daily_mode:
+    env_mode = os.environ.get("VT_MODE", "").strip().lower()
+    is_audit = args.audit_unseen or (env_mode == "audit_unseen")
+    is_daily = args.daily_mode or (env_mode == "daily_scan")
+
+    if is_audit:
+        if not api_key:
+            print("ERROR: VIRUS_TOTAL_API_KEY required for audit mode")
+            return 1
+        raw_env_limit = os.environ.get("VT_BATCH_LIMIT", "").strip()
+        env_limit = int(raw_env_limit) if raw_env_limit.isdigit() else None
+        batch_limit = args.batch_limit if args.batch_limit is not None else (env_limit or cfg.default_audit_batch_limit)
+        unseen_output = args.unseen_output or cfg.unseen_output_file
+        return audit_unseen_mode(
+            files_to_scan,
+            api_key,
+            cfg,
+            args.artifacts_dir,
+            batch_limit,
+            unseen_output,
+            args.unseen_json
+        )
+
+    if is_daily:
         if not api_key:
             print("ERROR: API key required for daily mode")
             return 1
@@ -356,4 +569,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main())

--- a/.github/workflows/virustotal-daily-scan.yml
+++ b/.github/workflows/virustotal-daily-scan.yml
@@ -3,9 +3,21 @@ name: VirusTotal Daily Background Scan
 on:
   schedule:
     - cron: '0 0 * * *' # Every day at midnight UTC
-  workflow_dispatch: # Allow manual trigger
-
-
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Scan Mode'
+        required: true
+        default: 'daily_scan'
+        type: choice
+        options:
+          - daily_scan
+          - audit_unseen
+      batch_limit:
+        description: 'Batch limit for audit mode (Free tier daily quota is 500)'
+        required: false
+        default: '450'
+        type: string
 
 permissions:
   contents: read
@@ -39,15 +51,26 @@ jobs:
       - name: Find all PDFs
         run: python .github/scripts/find-files.py --all
 
-      - name: Run Daily Scan
+      - name: Run Scan
         id: vt-scan
         env:
           VIRUS_TOTAL_API_KEY: ${{ secrets.VIRUS_TOTAL_API_KEY }}
+          VT_MODE: ${{ inputs.mode || 'daily_scan' }}
+          VT_BATCH_LIMIT: ${{ inputs.batch_limit || '450' }}
         run: |
           python .github/scripts/virus-total-scan.py \
             files_to_process.txt \
-            --daily-mode \
             --artifacts-dir .github/artifacts
+
+      - name: Upload Unseen PDFs Artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unseen-pdfs-to-submit
+          path: |
+            unseen_pdfs_to_submit.txt
+            unseen_pdfs_to_submit.json
+          if-no-files-found: ignore
 
       - name: Open Issue on Malicious Finding
         if: failure()


### PR DESCRIPTION
### Purpose
- Audits PDF file SHA-256 hashes against VirusTotal v3 API using existing repository secret VIRUS_TOTAL_API_KEY.
- Discovers PDF reports never seen by VirusTotal (HTTP 404) and generates downloadable artifacts (unseen_pdfs_to_submit.txt and unseen_pdfs_to_submit.json).
- Fixes defect in daily_scan_mode where encountering an already-scanned report (HTTP 200) terminated processing prematurely instead of continuing to search for an unscanned report to upload.
- Adds mode and batch_limit inputs to workflow_dispatch in .github/workflows/virustotal-daily-scan.yml.